### PR TITLE
Update TECHNOLOGY global with library names

### DIFF
--- a/klayout_dot_config/python/SiEPIC/scripts.py
+++ b/klayout_dot_config/python/SiEPIC/scripts.py
@@ -469,7 +469,7 @@ def path_to_waveguide(params=None, cell=None, snap=True, lv_commit=True, GUI=Fal
                                                                     "widths": [wg['width'] for wg in params['wgs']],
                                                                     "offsets": [wg['offset'] for wg in params['wgs']]})
                     print("SiEPIC.scripts.path_to_waveguide(): Waveguide from %s, %s" %
-                      (TECHNOLOGY['technology_name'], pcell))   
+                      (lib_name, pcell))   
                     if pcell:
                         break
 #                print("SiEPIC.scripts.path_to_waveguide(): Waveguide from %s, %s; time = %s" %

--- a/klayout_dot_config/python/SiEPIC/scripts.py
+++ b/klayout_dot_config/python/SiEPIC/scripts.py
@@ -459,6 +459,25 @@ def path_to_waveguide(params=None, cell=None, snap=True, lv_commit=True, GUI=Fal
                 pass
         if not pcell:
             try:
+                for lib_name in TECHNOLOGY['libraries']:
+                    pcell = ly.create_cell("Waveguide", lib_name, { "path": Dpath,
+                                                                    "radius": params['radius'],
+                                                                    "width": params['width'],
+                                                                    "adiab": params['adiabatic'],
+                                                                    "bezier": params['bezier'],
+                                                                    "layers": [wg['layer'] for wg in params['wgs']],
+                                                                    "widths": [wg['width'] for wg in params['wgs']],
+                                                                    "offsets": [wg['offset'] for wg in params['wgs']]})
+                    print("SiEPIC.scripts.path_to_waveguide(): Waveguide from %s, %s" %
+                      (TECHNOLOGY['technology_name'], pcell))   
+                    if pcell:
+                        break
+#                print("SiEPIC.scripts.path_to_waveguide(): Waveguide from %s, %s; time = %s" %
+#                  (TECHNOLOGY['technology_name'], pcell, time.perf_counter()-time0))   
+            except:
+                pass
+        if not pcell:
+            try:
                 pcell = ly.create_cell("Waveguide", "SiEPIC General", {"path": Dpath,
                                                                        "radius": params['radius'],
                                                                        "width": params['width'],

--- a/klayout_dot_config/python/SiEPIC/utils/__init__.py
+++ b/klayout_dot_config/python/SiEPIC/utils/__init__.py
@@ -98,6 +98,9 @@ def get_library_names(tech_name, verbose=False):
     else:
         print("Cannot get library names since KLayout version is <= 22")
     
+    if not library_names:
+        print("No libraries associated to {} technology".format(tech_name))
+    
     return library_names
 
 def get_technology_by_name(tech_name, verbose=False):

--- a/klayout_dot_config/python/SiEPIC/utils/__init__.py
+++ b/klayout_dot_config/python/SiEPIC/utils/__init__.py
@@ -6,6 +6,7 @@ List of functions:
 
 
 advance_iterator
+get_library_names
 get_technology_by_name
 get_technology
 load_Waveguides
@@ -81,6 +82,23 @@ import SiEPIC.utils
 SiEPIC.utils.get_technology_by_name('EBeam')
 '''
 
+# Returns a list of library names associated to the given technology name
+def get_library_names(tech_name, verbose=False):
+    if verbose:
+        print("get_library_names()")
+    
+    from .._globals import KLAYOUT_VERSION
+    
+    library_names = []
+    if KLAYOUT_VERSION > 22:
+        for lib_name in pya.Library.library_names():
+            library = pya.Library.library_by_name(lib_name)
+            if tech_name in library.technologies():
+                library_names.append(lib_name)
+    else:
+        print("Cannot get library names since KLayout version is <= 22")
+    
+    return library_names
 
 def get_technology_by_name(tech_name, verbose=False):
     if verbose:
@@ -155,7 +173,11 @@ def get_technology_by_name(tech_name, verbose=False):
         else:
             technology[k['name']] = pya.LayerInfo(
                 int(layerInfo.split('/')[0]), int(layerInfo.split('/')[1]))
+    
+    # Get library names
+    technology['libraries'] = get_library_names(tech_name)
 
+    
     return technology
 # end of get_technology_by_name(tech_name)
 # test example: give it a name of a technology, e.g., GSiP
@@ -186,6 +208,10 @@ def get_technology(verbose=False, query_activecellview_technology=False):
         print("No view selected")
         technology['dbu'] = 0.001
         technology['technology_name'] = technology_name
+        
+        # Get library names
+        technology['libraries'] = get_library_names(technology_name)
+        
         return technology
 
     # "lv.active_cellview().technology" crashes in KLayout 0.24.10 when loading a GDS file (technology not defined yet?) but works otherwise
@@ -222,6 +248,10 @@ def get_technology(verbose=False, query_activecellview_technology=False):
                     int(layerInfo.split('/')[0]), int(layerInfo.split('/')[1]))
             technology[itr.current().name + '_color'] = itr.current().fill_color
             itr.next()
+            
+    # Get library names
+    technology['libraries'] = get_library_names(technology_name)
+    
     return technology
 
 


### PR DESCRIPTION
Path to Waveguide method uses the technology name as the library name when creating waveguide cells, but the Waveguide PCell may be located in a different library under a different name from the tech name. 

- Added method to extract library names associated to a given tech name.
- Added get lib names to `get_technology()` and `get_technology_by_name()`
- Added if statement in path-to-waveguide method to look through each library.

The get lib names method allows for additional libraries to be detected and used.