### PR TITLE
Patch 2

### DIFF
--- a/klayout_dot_config/python/SiEPIC/utils/__init__.py
+++ b/klayout_dot_config/python/SiEPIC/utils/__init__.py
@@ -347,7 +347,6 @@ def load_Waveguides_by_Tech(tech_name, debug=False):
         for path1 in paths:
             with open(path1, 'r') as file:
                 waveguides1 = xml_to_dict(file.read())
-                print(waveguides1)
                 try:
                     waveguides.append(waveguides1['waveguides']['waveguide'])
                 except:

--- a/klayout_dot_config/python/SiEPIC/utils/__init__.py
+++ b/klayout_dot_config/python/SiEPIC/utils/__init__.py
@@ -347,8 +347,9 @@ def load_Waveguides_by_Tech(tech_name, debug=False):
         for path1 in paths:
             with open(path1, 'r') as file:
                 waveguides1 = xml_to_dict(file.read())
+                print(waveguides1)
                 try:
-                    waveguides += waveguides1['waveguides']['waveguide']
+                    waveguides.append(waveguides1['waveguides']['waveguide'])
                 except:
                     pass
         for waveguide in waveguides:


### PR DESCRIPTION
This fix allows for a singular waveguide to be defined in the WAVEGUIDES.xml file. Otherwise, WAVEGUIDES.xml could not be loaded (see image). 
![image](https://user-images.githubusercontent.com/15710134/126236958-11e48691-8b42-457f-8904-ce9b42212334.png)
