### PR TITLE
Caching Fix, FDTD Fix, Waveguide Handling

### DIFF
--- a/klayout_dot_config/python/SiEPIC/lumerical/fdtd.py
+++ b/klayout_dot_config/python/SiEPIC/lumerical/fdtd.py
@@ -631,7 +631,7 @@ def generate_component_sparam(do_simulation = True, addto_CML = True, verbose = 
         location = (p.center.x-component.DevRec_polygon.bbox().left+0.)/component.DevRec_polygon.bbox().width()
         print(location)
       t+= 'addport(component, "%s", "Bidirectional", "Optical Signal", "%s",%s);\n' %(p.pin_name,port_dict2[p.rotation],location)
-      t+= 'connect(component+"::RELAY_%s", "port", component+"::SPAR_1", "port %s");\n' % (count, count)
+      t+= 'connect(component+"::RELAY_%s", "port", component+"::SPAR_1", "opt%s");\n' % (count, count)
     lumapi.evalScript(_globals.INTC, t)
 
 

--- a/klayout_dot_config/python/SiEPIC/utils/__init__.py
+++ b/klayout_dot_config/python/SiEPIC/utils/__init__.py
@@ -83,8 +83,8 @@ SiEPIC.utils.get_technology_by_name('EBeam')
 '''
 
 # Returns a list of library names associated to the given technology name
-from functools import lru_cache
-@lru_cache(maxsize=32)
+#from functools import lru_cache
+#@lru_cache(maxsize=32)
 def get_library_names(tech_name, verbose=False):
     if verbose:
         print("get_library_names()")
@@ -362,7 +362,11 @@ def load_Waveguides_by_Tech(tech_name, debug=False):
             with open(path1, 'r') as file:
                 waveguides1 = xml_to_dict(file.read())
                 try:
-                    waveguides.append(waveguides1['waveguides']['waveguide'])
+                    if type(waveguides1['waveguides']['waveguide']) == list:
+                        for waveguide in waveguides1['waveguides']['waveguide']:
+                            waveguides.append(waveguide)
+                    else:
+                        waveguides.append(waveguides1['waveguides']['waveguide'])
                 except:
                     pass
         for waveguide in waveguides:


### PR DESCRIPTION
Caching fix for issue #155.
FDTD simulation fix compact model optical port names (due to Lumerical changing standard naming on optical ports).
Waveguide handling generated lists of waveguides.