### PR TITLE
Minor change to Line 89 of layout.py

### DIFF
--- a/klayout_dot_config/python/SiEPIC/utils/layout.py
+++ b/klayout_dot_config/python/SiEPIC/utils/layout.py
@@ -93,7 +93,7 @@ def layout_waveguide2(TECHNOLOGY, layout, cell, layers, widths, offsets, pts, ra
     wg_polygon = Polygon(translate_from_normal(wg_pts, width/2 + (offset if turn > 0 else - offset))+translate_from_normal(wg_pts, -width/2 + (offset if turn > 0 else - offset))[::-1])
     cell.shapes(layer).insert(wg_polygon)
   
-    if layout.layer(TECHNOLOGY['Waveguide']) == layer:
+    if layout.layer(TECHNOLOGY[layers[lr]]) == layer:
       waveguide_length = wg_polygon.area() / width * dbu
   return waveguide_length
 


### PR DESCRIPTION
Suggest change to Line 89 to allow length to be calculated for any layer, not just layers named "Waveguides". The current wording causes a failure in the waveguide generation of the Applied Nanotools PDK since we call our Si layer "Device Layer Full Etch".