### PR TITLE
Automatic Waveguide SBend

### DIFF
--- a/klayout_dot_config/python/SiEPIC/utils/geometry.py
+++ b/klayout_dot_config/python/SiEPIC/utils/geometry.py
@@ -217,9 +217,12 @@ def _bezier_optimal(angle0, angle3):
     except:
         from SiEPIC.install import install_scipy
         install_scipy()
-
-    from scipy.optimize import minimize
-
+    
+    try:
+      from scipy.optimize import minimize
+    except:
+      opt =   scipy.optimize()
+      minimize = opt.minimize()
 
 
     angle0 = fix_angle(angle0)

--- a/klayout_dot_config/python/SiEPIC/utils/layout.py
+++ b/klayout_dot_config/python/SiEPIC/utils/layout.py
@@ -24,8 +24,8 @@ from numpy import cos, sin, pi, sqrt
 import math as m
 
 from functools import reduce
-from .utils.sampling import sample_function
-from .utils.geometry import rotate90, rotate, bezier_optimal, curve_length
+from .sampling import sample_function
+from .geometry import rotate90, rotate, bezier_optimal, curve_length
 
 '''
 Create a waveguide, in a specific technology

--- a/klayout_dot_config/python/SiEPIC/utils/layout.py
+++ b/klayout_dot_config/python/SiEPIC/utils/layout.py
@@ -24,8 +24,8 @@ from numpy import cos, sin, pi, sqrt
 import math as m
 
 from functools import reduce
-from SiEPIC.utils.sampling import sample_function
-from SiEPIC.utils.geometry import rotate90, rotate, bezier_optimal, curve_length
+from .utils.sampling import sample_function
+from .utils.geometry import rotate90, rotate, bezier_optimal, curve_length
 
 '''
 Create a waveguide, in a specific technology
@@ -381,17 +381,15 @@ def layout_waveguide2(TECHNOLOGY, layout, cell, layers, widths, offsets, pts, ra
             
             #determine if waveguide does an S-Shape
             if i < len(pts)-2:
-                angle0 = angle_vector(pts[i]-pts[i-1])/90
                 angle2 = angle_vector(pts[i+2]-pts[i+1])/90
-                if angle0 == angle2 and dis2<2*pt_radius:  
+                if angle == angle2 and dis2<2*pt_radius:  
                     dis3 = pts[i+2].distance(pts[i+1])
                     h = pts[i+1].y- pts[i].y if not (angle%2) else pts[i+1].x- pts[i].x
                     theta = m.acos(float(pt_radius-abs(h/2))/pt_radius)*180/pi
-                    curved_l = int(2*pt_radius*sin(theta/180.0*pi))                 
-                    if dis1 < curved_l/2 or (dis3) < curved_l/2: pass # Check if there is clearance for the bend
-                    elif i < len(pts)-3 and (dis3 - pt_radius) < curved_l/2: pass# And check if there is clearance for the bend when there is a turn afterwards
+                    curved_l = int(2*pt_radius*sin(theta/180.0*pi))                  
+                    if (i > len(pts)-3 or i<3) and (dis2 < curved_l/2 or dis3 < curved_l/2): pass# Check if there is partial clearance for the bend when there is an end near
+                    elif (dis1 - pt_radius) < curved_l/2 or (dis3 - pt_radius) < curved_l/2: pass # Check if there is full clearance for the bend
                     else:
-                      print ('Inserting SBend at (%s, %s) with heigth %s and length %s'%(pts[i].x,pts[i].y, h, curved_l))
                       if not (angle%2):
                         t = pya.Trans(angle,0,pts[i].x-int(curved_l/2), pts[i].y)  
                       else :
@@ -403,7 +401,7 @@ def layout_waveguide2(TECHNOLOGY, layout, cell, layers, widths, offsets, pts, ra
                       continue                   
             # determine the radius, based on how much space is available
             if len(pts) == 3:
-                # simple corner, limit radius by the two edges                
+                # simple corner, limit radius by the two edges
                 if dis1 < pt_radius:
                     error_seg1 = True
                 if dis2 < pt_radius:

--- a/klayout_dot_config/python/SiEPIC/utils/layout.py
+++ b/klayout_dot_config/python/SiEPIC/utils/layout.py
@@ -349,7 +349,7 @@ by Lukas Chrostowski
 '''
 
 
-def layout_waveguide2(TECHNOLOGY, layout, cell, layers, widths, offsets, pts, radius, adiab, bezier, sbends = False):
+def layout_waveguide2(TECHNOLOGY, layout, cell, layers, widths, offsets, pts, radius, adiab, bezier, sbends = True):
     from SiEPIC.utils import arc_xy, arc_bezier, angle_vector, angle_b_vectors, inner_angle_b_vectors, translate_from_normal
     from SiEPIC.extend import to_itype
     from SiEPIC.utils.geometry import bezier_parallel
@@ -392,10 +392,11 @@ def layout_waveguide2(TECHNOLOGY, layout, cell, layers, widths, offsets, pts, ra
                     if (i > len(pts)-3 or i<3) and (dis1 < curved_l/2 or dis3 < curved_l/2): pass# Check if there is partial clearance for the bend when there is an end near
                     elif (dis1 - pt_radius) < curved_l/2 or (dis3 - pt_radius) < curved_l/2: pass # Check if there is full clearance for the bend
                     else:
+                      
                       if not (angle%2):
-                        t = pya.Trans(angle,0,pts[i].x-int(curved_l/2), pts[i].y)  
-                      else :
-                        t = pya.Trans(angle,1,pts[i].x, pts[i].y-int(curved_l/2))
+                        t = pya.Trans(angle, (angle == 2), pts[i].x+(angle-1)*int(curved_l/2), pts[i].y)  
+                      else:
+                        t = pya.Trans(angle, (angle == 1), pts[i].x, pts[i].y-(angle)*int(curved_l/2))
                       bend_pts = pya.DPath(bezier_parallel(pya.DPoint(0, 0), pya.DPoint(curved_l*dbu, h*dbu), 0),0).to_itype(dbu).transformed(t)
                       wg_pts += bend_pts.each_point()
                       turn = 0

--- a/klayout_dot_config/python/SiEPIC/utils/layout.py
+++ b/klayout_dot_config/python/SiEPIC/utils/layout.py
@@ -387,7 +387,7 @@ def layout_waveguide2(TECHNOLOGY, layout, cell, layers, widths, offsets, pts, ra
                     h = pts[i+1].y- pts[i].y if not (angle%2) else pts[i+1].x- pts[i].x
                     theta = m.acos(float(pt_radius-abs(h/2))/pt_radius)*180/pi
                     curved_l = int(2*pt_radius*sin(theta/180.0*pi))                  
-                    if (i > len(pts)-3 or i<3) and (dis2 < curved_l/2 or dis3 < curved_l/2): pass# Check if there is partial clearance for the bend when there is an end near
+                    if (i > len(pts)-3 or i<3) and (dis1 < curved_l/2 or dis3 < curved_l/2): pass# Check if there is partial clearance for the bend when there is an end near
                     elif (dis1 - pt_radius) < curved_l/2 or (dis3 - pt_radius) < curved_l/2: pass # Check if there is full clearance for the bend
                     else:
                       if not (angle%2):


### PR DESCRIPTION
Inserts waveguide bends #153  as part of the guiding line that generates the waveguide. The SBend takes precedence over the creation of normal bends where it's possible to install them, but they are only placed provided a normal bend doesn't fit. It uses the Bezier Parallel function from SiEPIC.utils.geometry.

Here are some images of how the Bends look.
![image](https://user-images.githubusercontent.com/14344419/185619172-218e48f2-ac74-46f9-a309-bf5bdcd669d9.png)

Tested it against EBeam, Athabasca, AMF, and others and it seems to be working fine in all. 

Concerns:
- The warning for radius clearance appears even if an SBend can be placed on the site. 
-  I had to do a weird import for the optimizer to work on my end. I don't know what functions, other than the optimal bezier one, are using it so I couldn't track if it affected anything else.