### PR TITLE
Allow grouped layer groups (deep layer deck)

### DIFF
--- a/klayout_dot_config/python/SiEPIC/utils/__init__.py
+++ b/klayout_dot_config/python/SiEPIC/utils/__init__.py
@@ -222,29 +222,20 @@ def get_technology_by_name(tech_name, verbose=False):
     else:
         layer_dict = xml_dict['layer-properties']['properties']
    
-   
     file.close()
-
-    for k in layer_dict:
-        layerInfo = k['source'].split('@')[0]
-        if 'group-members' in k:
-            # encoutered a layer group, look inside:
-            j = k['group-members']
-            if 'name' in j:
-                layerInfo_j = j['source'].split('@')[0]
-                technology[j['name']] = pya.LayerInfo(
-                    int(layerInfo_j.split('/')[0]), int(layerInfo_j.split('/')[1]))
-            else:
-                for j in k['group-members']:
-                    layerInfo_j = j['source'].split('@')[0]
-                    technology[j['name']] = pya.LayerInfo(
-                        int(layerInfo_j.split('/')[0]), int(layerInfo_j.split('/')[1]))
-            if k['source'] != '*/*@*':
-                technology[k['name']] = pya.LayerInfo(
-                    int(layerInfo.split('/')[0]), int(layerInfo.split('/')[1]))
-        else:
-            technology[k['name']] = pya.LayerInfo(
-                int(layerInfo.split('/')[0]), int(layerInfo.split('/')[1]))
+    
+    def get_members(layer_dict, technology):
+        if isinstance(layer_dict, list):
+            for k in layer_dict:
+                get_members(k, technology)
+        elif 'group-members' in layer_dict:
+            get_members(layer_dict['group-members'], technology)
+        elif 'name' in layer_dict:
+            layerInfo = layer_dict['source'].split('@')[0]
+            if layer_dict['source'] != '*/*@*':
+                technology[layer_dict['name']] = pya.LayerInfo(int(layerInfo.split('/')[0]), int(layerInfo.split('/')[1]))
+        return technology
+    get_members(layer_dict, technology)
     
     # Get library names
     technology['libraries'] = get_library_names(tech_name)

--- a/klayout_dot_config/python/SiEPIC/utils/layout.py
+++ b/klayout_dot_config/python/SiEPIC/utils/layout.py
@@ -404,7 +404,7 @@ def layout_waveguide2(TECHNOLOGY, layout, cell, layers, widths, offsets, pts, ra
                     pt_radius = min(dis1/2, dis2/2, pt_radius)
 
             if error_seg1 or error_seg2:
-                if not error_layer:
+                if error_layer is None:
                     # we have an error, but no Error layer
                     print('- SiEPIC:layout_waveguide2: missing Error layer')
                 # and pt_radius < to_itype(radius,dbu):


### PR DESCRIPTION
## Allow grouped layer groups (deep layer deck)
Update layer reading to check for subgrouping in the Layer Deck specification, following the lyp specification for doing so (creating new grou_members inside a group_member inside a group_member ....).  [in https://www.klayout.de/lyp_format.html]

Nested groups in the layer deck can with this be used to allow extra categorization. For example:
![example](https://user-images.githubusercontent.com/14344419/182823036-41f05540-803c-4dd9-a07f-333e5c448118.png)

### Also in this commit:
Changed a line in layout_waveguide2 to avoid detecting the layer 'Errors' as non-existing when it's the 0 elements in the layout.layer() method.