### PR TITLE
Adding a Makefile and fix a bug related to the "Path to waveguide" feature.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LUMERICAL_DIR=$$HOME/.config/Lumerical
 
 install:
 	mkdir -p $(INSTALL_DIR)
-	cp -rv * $(INSTALL_DIR) 
+	cp -r * $(INSTALL_DIR) 
 
 	ln -s $(INSTALL_DIR)/klayout_dot_config/pymacros/* $(KLAYOUT_DIR)/pymacros/
 	ln -s $(INSTALL_DIR)/klayout_dot_config/python/* $(KLAYOUT_DIR)/python/
@@ -20,10 +20,10 @@ install:
 
 	if [ -f "$(LUMERICAL_DIR)/INTERCONNECT.ini.bak" ]; then rm "$(LUMERICAL_DIR)/INTERCONNECT.ini.bak"; fi
 
-	cp -v $(LUMERICAL_DIR)/INTERCONNECT.ini $(LUMERICAL_DIR)/INTERCONNECT.ini.bak
+	cp $(LUMERICAL_DIR)/INTERCONNECT.ini $(LUMERICAL_DIR)/INTERCONNECT.ini.bak
 
 	grep -q -F '[Design%20kits]' "$(LUMERICAL_DIR)/INTERCONNECT.ini" || echo '[Design%20kits]' >> "$(LUMERICAL_DIR)/INTERCONNECT.ini"
-	grep -q -F '/GSip' $(LUMERICAL_DIR)/INTERCONNECT.ini || cat $(LUMERICAL_DIR)/INTERCONNECT.ini | sed "/Design/a\ \nGSiP=$HOME/SiEPIC-Tools/Lumerical_CML_GSiP/GSiP\n" > $(LUMERICAL_DIR)/INTERCONNECT.ini
+	grep -q -F '/GSip' $(LUMERICAL_DIR)/INTERCONNECT.ini || (cat $(LUMERICAL_DIR)/INTERCONNECT.ini | sed "/Design/a\ \nGSiP=$(INSTALL_DIR)/Lumerical_CML_GSiP/GSiP\n" > $(LUMERICAL_DIR)/INTERCONNECT.ini)
 
 uninstall:
 	rm -rvf $(INSTALL_DIR)

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,13 @@ KLAYOUT_DIR=$$HOME/.klayout
 INSTALL_DIR=$$HOME/SiEPIC-Tools
 LUMERICAL_DIR=$$HOME/.config/Lumerical
 
-install:
+all: copyall klayout lumerical
+
+copyall:
 	mkdir -p $(INSTALL_DIR)
 	cp -r * $(INSTALL_DIR) 
 
+klayout:
 	ln -s $(INSTALL_DIR)/klayout_dot_config/pymacros/* $(KLAYOUT_DIR)/pymacros/
 	ln -s $(INSTALL_DIR)/klayout_dot_config/python/* $(KLAYOUT_DIR)/python/
 	ln -s $(INSTALL_DIR)/Python_packages_for_KLayout/python/* $(KLAYOUT_DIR)/python/
@@ -13,6 +16,7 @@ install:
 	mkdir -p "$(KLAYOUT_DIR)/tech"
 	ln -s $(INSTALL_DIR)/klayout_dot_config/tech/* $(KLAYOUT_DIR)/tech/
 
+lumerical:
 	mkdir -p "$(LUMERICAL_DIR)/Custom"
 	ln -s $(INSTALL_DIR)/Lumerical_CML_GSiP/GSiP/* $(LUMERICAL_DIR)/Custom/
 
@@ -22,17 +26,14 @@ install:
 
 	cp $(LUMERICAL_DIR)/INTERCONNECT.ini $(LUMERICAL_DIR)/INTERCONNECT.ini.bak
 
-	grep -q -F '[Design%20kits]' "$(LUMERICAL_DIR)/INTERCONNECT.ini" || echo '[Design%20kits]' >> "$(LUMERICAL_DIR)/INTERCONNECT.ini"
-	grep -q -F '/GSip' $(LUMERICAL_DIR)/INTERCONNECT.ini || (cat $(LUMERICAL_DIR)/INTERCONNECT.ini | sed "/Design/a\ \nGSiP=$(INSTALL_DIR)/Lumerical_CML_GSiP/GSiP\n" > $(LUMERICAL_DIR)/INTERCONNECT.ini)
+	crudini --set $(LUMERICAL_DIR)/INTERCONNECT.ini "Design%20kits" GSIP $(INSTALL_DIR)/Lumerical_CML_GSIP/GSIP
 
 uninstall:
-	rm -rvf $(INSTALL_DIR)
+	rm -r $(INSTALL_DIR)
 
 	find $(KLAYOUT_DIR)/pymacros/ -xtype l -delete
 	find $(KLAYOUT_DIR)/python/ -xtype l -delete
 	find $(KLAYOUT_DIR)/tech/ -xtype l -delete
 	find $(LUMERICAL_DIR)/Custom/ -xtype l -delete
 
-	cp $(LUMERICAL_DIR)/INTERCONNECT.ini $(LUMERICAL_DIR)/INTERCONNECT.ini.bak.bak
-	mv $(LUMERICAL_DIR)/INTERCONNECT.ini.bak $(LUMERICAL_DIR)/INTERCONNECT.ini
-	mv $(LUMERICAL_DIR)/INTERCONNECT.ini.bak.bak $(LUMERICAL_DIR)/INTERCONNECT.ini.bak
+	crudini --del $(LUMERICAL_DIR)/INTERCONNECT.ini "Design%20kits" GSIP

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+KLAYOUT_DIR=$$HOME/.klayout
+INSTALL_DIR=$$HOME/SiEPIC-Tools
+LUMERICAL_DIR=$$HOME/.config/Lumerical
+
+install:
+	mkdir -p $(INSTALL_DIR)
+	cp -rv * $(INSTALL_DIR) 
+
+	ln -s $(INSTALL_DIR)/klayout_dot_config/pymacros/* $(KLAYOUT_DIR)/pymacros/
+	ln -s $(INSTALL_DIR)/klayout_dot_config/python/* $(KLAYOUT_DIR)/python/
+	ln -s $(INSTALL_DIR)/Python_packages_for_KLayout/python/* $(KLAYOUT_DIR)/python/
+
+	mkdir -p "$(KLAYOUT_DIR)/tech"
+	ln -s $(INSTALL_DIR)/klayout_dot_config/tech/* $(KLAYOUT_DIR)/tech/
+
+	mkdir -p "$(LUMERICAL_DIR)/Custom"
+	ln -s $(INSTALL_DIR)/Lumerical_CML_GSiP/GSiP/* $(LUMERICAL_DIR)/Custom/
+
+	# Create a backup file of the configuration and delete the old one
+
+	if [ -f "$(LUMERICAL_DIR)/INTERCONNECT.ini.bak" ]; then rm "$(LUMERICAL_DIR)/INTERCONNECT.ini.bak"; fi
+
+	cp -v $(LUMERICAL_DIR)/INTERCONNECT.ini $(LUMERICAL_DIR)/INTERCONNECT.ini.bak
+
+	grep -q -F '[Design%20kits]' "$(LUMERICAL_DIR)/INTERCONNECT.ini" || echo '[Design%20kits]' >> "$(LUMERICAL_DIR)/INTERCONNECT.ini"
+	grep -q -F '/GSip' $(LUMERICAL_DIR)/INTERCONNECT.ini || cat $(LUMERICAL_DIR)/INTERCONNECT.ini | sed "/Design/a\ \nGSiP=$HOME/SiEPIC-Tools/Lumerical_CML_GSiP/GSiP\n" > $(LUMERICAL_DIR)/INTERCONNECT.ini
+
+uninstall:
+	rm -rvf $(INSTALL_DIR)
+
+	find $(KLAYOUT_DIR)/pymacros/ -xtype l -delete
+	find $(KLAYOUT_DIR)/python/ -xtype l -delete
+	find $(KLAYOUT_DIR)/tech/ -xtype l -delete
+	find $(LUMERICAL_DIR)/Custom/ -xtype l -delete
+
+	cp $(LUMERICAL_DIR)/INTERCONNECT.ini $(LUMERICAL_DIR)/INTERCONNECT.ini.bak.bak
+	mv $(LUMERICAL_DIR)/INTERCONNECT.ini.bak $(LUMERICAL_DIR)/INTERCONNECT.ini
+	mv $(LUMERICAL_DIR)/INTERCONNECT.ini.bak.bak $(LUMERICAL_DIR)/INTERCONNECT.ini.bak

--- a/klayout_dot_config/python/SiEPIC/utils/layout.py
+++ b/klayout_dot_config/python/SiEPIC/utils/layout.py
@@ -298,7 +298,7 @@ def layout_waveguide3(cell, pts, params, debug=True):
     pt5 = pts[0] + 2*dpt
 
     t = Trans(angle, False, pt3)
-    text = Text('Lumerical_INTERCONNECT_library=%s' % CML, t, 0.1*wg_width, -1)
+    text = Text('Lumerical_INTERCONNECT_library=Design kits/%s' % CML, t, 0.1*wg_width, -1)
     text.halign = halign
     shape = cell.shapes(LayerDevRecN).insert(text)
     t = Trans(angle, False, pt2)


### PR DESCRIPTION
Hi.

I am taking the course in Silicon Photonics as part of my PhD studies at KTH Royal Institute of Technology. Came across a bug where the circuit simulation in Lumerical INTERCONNECT started from KLayout is non-functioning on Linux (i.e. Ubuntu 22.04 LTS). After pressing "Simulation" in KLayout one will find that:

`INTERCONNECT: " Checking for errors... Found empty result: input 1/mode 1/gain in element ona_1`

I have investigated this error and found out that SiEPIC-Tools generates a SPICE file without prepending `Design kits/` with the library name `EBeam`. This occurs at the time one uses the function "Path to Waveguide" in KLayout.

By applying the following patch as I have included under https://github.com/SiEPIC/SiEPIC-Tools/commit/722f58cc6f39137dd74859b3734ce1fb37dace25 I have successfully resolved the issue. With that said, I have no idea whether this is the "right" solution to the problem. 

I've also included a Makefile which was of help when I developed this patch. To install the patch on Ubuntu, all you need to do is to type the following commands in the terminal (while being in the same folder as the `Makefile`):
``` 
sudo apt install crudini
make all
```
The software `crudini` was preferred to `sed` and `grep` when because it was cleaner in terms of readability. The "only" price to pay is portability. :-)

I would be glad to get feedback from the maintainer about this pull request. 

Kind regards,
Olof