### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM quay.io/centos/centos:stream8
 
+# CentOS 8 reached EOL Dec 31, 2021. Therefore, mirrors need to be change to the following
+RUN cd /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 # Update the system and install necessary tools.
 RUN dnf -y update && \
     dnf -y install wget bzip2 unzip git mesa-dri-drivers python3 python3-pip


### PR DESCRIPTION
Fix CentOS 8 compilation to ensure build proceeds.

CentOS 8 EOL occurred Dec 31, 2021 meaning running Linux package updates or installations need to point to the correct archives.