### PR TITLE
Fix for: Circuit Simulation: OPICS - "Unable to import the library: opics_ebeam" #303

### DIFF
--- a/klayout_dot_config/python/SiEPIC/opics/utils.py
+++ b/klayout_dot_config/python/SiEPIC/opics/utils.py
@@ -330,7 +330,6 @@ def NetlistProcessor(spice_filepath, Network, libraries, c_, circuitData, verbos
                             # Look for the specific file path
                             potential_paths = [
                                 os.path.join(klayout_salt_dir, 'siepic_ebeam_pdk', 'EBeam', 'pymacros', 'opics_ebeam'),
-                                os.path.join(klayout_salt_dir, 'siepic-ebeam-pdk', 'EBeam', 'pymacros', 'opics_ebeam'),
                             ]
                             
                             for path in potential_paths:
@@ -357,13 +356,7 @@ def NetlistProcessor(spice_filepath, Network, libraries, c_, circuitData, verbos
                         libs_comps[each_lib] = opics_lib.component_factory
                         
                     except Exception as e:
-                        debug_str = "\n".join(debug_info + [
-                            f"Second import error: {str(e)}",
-                            f"KLayout salt directory exists: {os.path.exists(klayout_salt_dir) if 'klayout_salt_dir' in locals() else 'Not checked'}",
-                            f"Full sys.path: {sys.path}",
-                            f"Potential opics_ebeam paths checked: {potential_paths if 'potential_paths' in locals() else 'None'}"
-                        ])
-                        raise Exception('Unable to import the library: %s. Please ensure siepic_ebeam_pdk is installed via KLayout package manager. Error: %s\n\nDebug Information:\n%s' % (opics_lib_name, str(e), debug_str))
+                        raise Exception('Unable to import the library: %s. Please ensure siepic_ebeam_pdk is installed via KLayout package manager. Error: %s\n\nDebug Information:\n' % (opics_lib_name, str(e)))
             else:
                 # Original code for other libraries
                 opics_lib_name = "opics_"+each_lib


### PR DESCRIPTION
Link to same issue by another user: https://github.com/SiEPIC/SiEPIC_EBeam_PDK/discussions/303#discussion-7363757
(the code change needed to be done here)


Hi Lukas,

When installing KLayout, SiEPIC-tools and SiEPIC_EBeam_PDK, there was a bug on both Windows 11 (AMD 5900X and Radeon 7900 XTX) and MacOS (M1 MBP). The error was as follows:

Whenever I:

- Load the example MZM layout
- Run an OPICS simulation

Exception: Unable to import the library: opics_ebeam
  C:\Users\maxzh\KLayout\salt\siepic_tools\python\SiEPIC\opics\utils.py:312
  C:\Users\maxzh\KLayout\salt\siepic_tools\python\SiEPIC\opics_netlist_sim.py:90
  C:/Users/maxzh/KLayout/salt/siepic_tools/pymacros\Keybindings\Simulation\circuit_simulation OPICS.lym:7

Seems to me like the code is trying to import the package 'ebeam' specified in 'catalogue.yaml', but either never downloads it, or isn't using the 'ebeam' data provided by the PDK. The default directory where utils.py tries to find the package seems to be 'SiEPIC/opics/libraries', but that isn't the install location of the ebeam PDK when downloading using 'salt'. I tried simply copy and pasting the package to SiEPIC/opics/libraries, but that gave a new set of errors. I wrote some code to check and import from the correct directories. I agree it is not the most elegant solution, but I simply needed a working version to complete the passives workshop. Here it is!

Thank you,
Max.