### PR TITLE
Adding Euler Bend Capability

### DIFF
--- a/klayout_dot_config/python/SiEPIC/core.py
+++ b/klayout_dot_config/python/SiEPIC/core.py
@@ -380,16 +380,16 @@ class WaveguideGUI():
         self.window.findChild('ok').clicked(self.ok)
         self.window.findChild('cancel').clicked(self.close)
         self.window.findChild('adiabatic').toggled(self.enable)
-        self.window.findChild('bezier').setEnabled(False)
+        self.window.findChild('bend_parameter').setEnabled(False)
         self.window.findChild("configuration").currentIndexChanged(self.config_changed)
         self.loaded_technology = ''
         self.clicked = True
 
     def enable(self, val):
         if self.window.findChild('adiabatic').isChecked():
-            self.window.findChild('bezier').setEnabled(True)
+            self.window.findChild('bend_parameter').setEnabled(True)
         else:
-            self.window.findChild('bezier').setEnabled(False)
+            self.window.findChild('bend_parameter').setEnabled(False)
 
     def update(self):
         from .utils import get_layout_variables, load_Waveguides_by_Tech
@@ -399,12 +399,18 @@ class WaveguideGUI():
         waveguide_types = load_Waveguides_by_Tech(tech_name)
         self.waveguides = waveguide_types
         # print ('SiEPIC.core, Waveguide GUI: tech %s, waveguide_types: %s' % (tech_name, waveguide_types) )
+        print('waveguide_types = {}'.format(waveguide_types))
         if 0:
             # keep only simple waveguides (not compound ones)
             waveguide_types_simple = [t for t in waveguide_types if not 'compound_waveguide' in t.keys()]
             self.waveguides = waveguide_types_simple
         try:
             self.options = [waveguide['name'] for waveguide in self.waveguides]
+            try:
+                print(self.waveguides[0])
+            except:
+                print('mm no')
+                pass
         except:
             raise Exception('No waveguides found for technology=%s. Check that there exists a technology definition file %s.lyt and a WAVEGUIDES.xml file in the PDK folder. \n(Error in SiEPIC.core.WaveguideGUI.update)' % (tech_name, tech_name) )
 #            raise Exception("Problem with waveguide configuration. Error in SiEPIC.core.WaveguideGUI.update")
@@ -441,7 +447,11 @@ class WaveguideGUI():
         else:
             # regular waveguide
             waveguide = params
-        if waveguide:
+        if waveguide:         
+            if 'bend_type' in waveguide:
+                self.window.findChild('bend_type').text = waveguide['bend_type']
+            else:
+                self.window.findChild('bend_type').text = 'bezier'
             if 'width' in waveguide:
                 self.window.findChild('width').text = waveguide['width']
             elif 'wg_width' in waveguide:
@@ -454,11 +464,10 @@ class WaveguideGUI():
                 self.window.findChild('radius').text = '5'
             if waveguide['adiabatic']:
                 self.window.findChild('adiabatic').setChecked(True)
-                self.window.findChild('bezier').text = str(waveguide['bezier'])
+                self.window.findChild('bend_parameter').text = str(waveguide['bend_parameter'])
             else:
                 self.window.findChild('adiabatic').setChecked(False)
-#                self.window.findChild('bezier').text = '0.45'  # 0.45 makes a radial bend
-                self.window.findChild('bezier').text = ''
+                self.window.findChild('bend_parameter').text = ''
                 
 # in 0.3.77, made the GUI read-only; returning back to editable in 0.3.79 based on user request
 #        self.window.findChild('bezier').setEnabled(False)
@@ -484,11 +493,12 @@ class WaveguideGUI():
 
         self.loaded_technology = TECHNOLOGY['technology_name']
         
-        bezier = self.window.findChild('bezier').text
+        bend_parameter = self.window.findChild('bend_parameter').text
         params = {'radius': float(self.window.findChild('radius').text),
                   'width': float(self.window.findChild('width').text),
                   'adiabatic': self.window.findChild('adiabatic').isChecked(),
-                  'bezier': 0 if bezier=='' else float(bezier),
+                  'bend_type': self.window.findChild('bend_type').text,
+                  'bend_parameter': 0 if bend_parameter=='' else float(bend_parameter),
                   'wgs': []}
 
         waveguide_type = self.window.findChild('configuration').currentText

--- a/klayout_dot_config/python/SiEPIC/core.py
+++ b/klayout_dot_config/python/SiEPIC/core.py
@@ -379,17 +379,18 @@ class WaveguideGUI():
         # Button Bindings
         self.window.findChild('ok').clicked(self.ok)
         self.window.findChild('cancel').clicked(self.close)
-        self.window.findChild('adiabatic').toggled(self.enable)
-        self.window.findChild('bend_parameter').setEnabled(False)
+        #self.window.findChild('adiabatic').toggled(self.enable)
+        self.window.findChild('bend_parameter').setEnabled(True)
         self.window.findChild("configuration").currentIndexChanged(self.config_changed)
         self.loaded_technology = ''
         self.clicked = True
 
     def enable(self, val):
-        if self.window.findChild('adiabatic').isChecked():
-            self.window.findChild('bend_parameter').setEnabled(True)
-        else:
-            self.window.findChild('bend_parameter').setEnabled(False)
+        print("function no longer does anything")
+        # if self.window.findChild('adiabatic').isChecked():
+        #     self.window.findChild('bend_parameter').setEnabled(True)
+        # else:
+        #     self.window.findChild('bend_parameter').setEnabled(False)
 
     def update(self):
         from .utils import get_layout_variables, load_Waveguides_by_Tech
@@ -445,7 +446,7 @@ class WaveguideGUI():
             if 'bend_type' in waveguide:
                 self.window.findChild('bend_type').text = waveguide['bend_type']
             else:
-                self.window.findChild('bend_type').text = 'bezier'
+                self.window.findChild('bend_type').text = 'Bezier'
             if 'width' in waveguide:
                 self.window.findChild('width').text = waveguide['width']
             elif 'wg_width' in waveguide:
@@ -457,18 +458,11 @@ class WaveguideGUI():
             else:
                 self.window.findChild('radius').text = '5'
             if waveguide['adiabatic']:
-                self.window.findChild('adiabatic').setChecked(True)
+                #self.window.findChild('adiabatic').setChecked(True)
                 self.window.findChild('bend_parameter').text = str(waveguide['bend_parameter'])
             else:
-                self.window.findChild('adiabatic').setChecked(False)
+                #self.window.findChild('adiabatic').setChecked(False)
                 self.window.findChild('bend_parameter').text = ''
-                
-# in 0.3.77, made the GUI read-only; returning back to editable in 0.3.79 based on user request
-#        self.window.findChild('bezier').setEnabled(False)
-#        self.window.findChild('adiabatic').setEnabled(False)
-#        self.window.findChild('radius').setEnabled(False)
-#        self.window.findChild('width').setEnabled(False)
-#        self.window.findChild('bezier').setEnabled(False)
 
 
     def get_parameters(self, show):
@@ -488,9 +482,16 @@ class WaveguideGUI():
         self.loaded_technology = TECHNOLOGY['technology_name']
         
         bend_parameter = self.window.findChild('bend_parameter').text
+        
+        if self.window.findChild('bend_type').text in ['Euler','Bezier']:
+            adiabatic_status = True
+        else:
+            adiabatic_status = False
+        
         params = {'radius': float(self.window.findChild('radius').text),
                   'width': float(self.window.findChild('width').text),
-                  'adiabatic': self.window.findChild('adiabatic').isChecked(),
+                  #'adiabatic': self.window.findChild('adiabatic').isChecked(),
+                  'adiabatic': adiabatic_status,
                   'bend_type': self.window.findChild('bend_type').text,
                   'bend_parameter': 0 if bend_parameter=='' else float(bend_parameter),
                   'wgs': []}

--- a/klayout_dot_config/python/SiEPIC/core.py
+++ b/klayout_dot_config/python/SiEPIC/core.py
@@ -399,18 +399,12 @@ class WaveguideGUI():
         waveguide_types = load_Waveguides_by_Tech(tech_name)
         self.waveguides = waveguide_types
         # print ('SiEPIC.core, Waveguide GUI: tech %s, waveguide_types: %s' % (tech_name, waveguide_types) )
-        print('waveguide_types = {}'.format(waveguide_types))
         if 0:
             # keep only simple waveguides (not compound ones)
             waveguide_types_simple = [t for t in waveguide_types if not 'compound_waveguide' in t.keys()]
             self.waveguides = waveguide_types_simple
         try:
             self.options = [waveguide['name'] for waveguide in self.waveguides]
-            try:
-                print(self.waveguides[0])
-            except:
-                print('mm no')
-                pass
         except:
             raise Exception('No waveguides found for technology=%s. Check that there exists a technology definition file %s.lyt and a WAVEGUIDES.xml file in the PDK folder. \n(Error in SiEPIC.core.WaveguideGUI.update)' % (tech_name, tech_name) )
 #            raise Exception("Problem with waveguide configuration. Error in SiEPIC.core.WaveguideGUI.update")

--- a/klayout_dot_config/python/SiEPIC/files/waveguide_gui.ui
+++ b/klayout_dot_config/python/SiEPIC/files/waveguide_gui.ui
@@ -3,14 +3,14 @@
  <class>MainWindow</class>
  <widget class="QDialog" name="MainWindow">
   <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
+   <enum>Qt::WindowModality::WindowModal</enum>
   </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
-    <height>250</height>
+    <width>717</width>
+    <height>432</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -28,61 +28,118 @@
   <property name="windowTitle">
    <string>Path to Waveguide</string>
   </property>
+  <property name="autoFillBackground">
+   <bool>false</bool>
+  </property>
   <layout class="QHBoxLayout" name="horizontalLayout_11">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
+    <layout class="QHBoxLayout" name="Global_Horz_Layout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
+     </property>
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout">
+      <layout class="QVBoxLayout" name="Global_Vert_Layout">
        <property name="sizeConstraint">
-        <enum>QLayout::SetMinimumSize</enum>
+        <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
        <item>
-        <widget class="QLabel" name="label_4">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-           <horstretch>1</horstretch>
-           <verstretch>1</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>250</width>
-           <height>20</height>
-          </size>
-         </property>
-         <property name="sizeIncrement">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="font">
-          <font>
-           <pointsize>16</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string>Waveguide Configurations</string>
-         </property>
-         <property name="scaledContents">
-          <bool>true</bool>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="wordWrap">
-          <bool>false</bool>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLabel" name="h01_Wvg_Config">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>250</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="sizeIncrement">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>16</pointsize>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="layoutDirection">
+            <enum>Qt::LayoutDirection::LeftToRight</enum>
+           </property>
+           <property name="autoFillBackground">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Waveguide Configurations</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::TextFormat::AutoText</enum>
+           </property>
+           <property name="scaledContents">
+            <bool>true</bool>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+           <property name="wordWrap">
+            <bool>false</bool>
+           </property>
+           <property name="margin">
+            <number>-1</number>
+           </property>
+           <property name="indent">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_7">
+        <layout class="QHBoxLayout" name="h02_Config_Line" stretch="0,0,3,0">
          <property name="spacing">
           <number>5</number>
          </property>
          <property name="sizeConstraint">
-          <enum>QLayout::SetMinimumSize</enum>
+          <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
          </property>
+         <property name="topMargin">
+          <number>5</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
+         <item>
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
          <item>
           <widget class="QLabel" name="label_10">
            <property name="sizePolicy">
@@ -103,6 +160,11 @@
              <height>0</height>
             </size>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
            <property name="text">
             <string>Configuration:</string>
            </property>
@@ -116,24 +178,42 @@
          </item>
          <item>
           <widget class="QComboBox" name="configuration">
-           <property name="minimumSize">
-            <size>
-             <width>125</width>
-             <height>25</height>
-            </size>
-           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>1</horstretch>
              <verstretch>1</verstretch>
             </sizepolicy>
            </property>
+           <property name="minimumSize">
+            <size>
+             <width>125</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
        <item>
-        <widget class="Line" name="line">
+        <widget class="Line" name="h03_Spacer">
          <property name="sizePolicy">
           <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
            <horstretch>1</horstretch>
@@ -153,58 +233,80 @@
           </size>
          </property>
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="label_15">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-           <horstretch>1</horstretch>
-           <verstretch>1</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>250</width>
-           <height>20</height>
-          </size>
-         </property>
-         <property name="sizeIncrement">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="font">
-          <font>
-           <pointsize>16</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string>Waveguide Specifications</string>
-         </property>
-         <property name="scaledContents">
-          <bool>true</bool>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="wordWrap">
-          <bool>false</bool>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QLabel" name="h04_Wvg_Specs">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>250</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="sizeIncrement">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>16</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Waveguide Specifications</string>
+           </property>
+           <property name="scaledContents">
+            <bool>true</bool>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+           <property name="wordWrap">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
-	   
-       <item> <!-- Width -->
-        <layout class="QHBoxLayout" name="horizontalLayout_8">
+       <item>
+        <layout class="QHBoxLayout" name="h05_Width_Line">
          <property name="spacing">
           <number>5</number>
          </property>
          <property name="sizeConstraint">
-          <enum>QLayout::SetMinimumSize</enum>
+          <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
          </property>
+         <property name="topMargin">
+          <number>5</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
          <item>
           <widget class="QLabel" name="label">
            <property name="sizePolicy">
@@ -224,6 +326,11 @@
              <width>0</width>
              <height>0</height>
             </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Width:</string>
@@ -250,11 +357,22 @@
              <height>0</height>
             </size>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
            <property name="text">
             <string>0.5</string>
            </property>
+           <property name="frame">
+            <bool>false</bool>
+           </property>
            <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -278,8 +396,13 @@
              <height>0</height>
             </size>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
            <property name="text">
-            <string>um</string>
+            <string>μm</string>
            </property>
            <property name="scaledContents">
             <bool>true</bool>
@@ -289,17 +412,48 @@
            </property>
           </widget>
          </item>
+         <item>
+          <spacer name="horizontalSpacer_9">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
        </item>
-	   
-       <item> <!-- Radius -->
-        <layout class="QHBoxLayout" name="horizontalLayout_8">
+       <item>
+        <layout class="QHBoxLayout" name="h06_Radius_Line">
          <property name="spacing">
           <number>5</number>
          </property>
          <property name="sizeConstraint">
-          <enum>QLayout::SetMinimumSize</enum>
+          <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
          </property>
+         <property name="topMargin">
+          <number>5</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
+         <item>
+          <spacer name="horizontalSpacer_6">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
          <item>
           <widget class="QLabel" name="label">
            <property name="sizePolicy">
@@ -320,11 +474,16 @@
              <height>0</height>
             </size>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
            <property name="text">
-            <string>Radius:</string> 
+            <string>Radius:</string>
            </property>
           </widget>
-         </item> 
+         </item>
          <item>
           <widget class="QLineEdit" name="radius">
            <property name="sizePolicy">
@@ -345,11 +504,22 @@
              <height>0</height>
             </size>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
            <property name="text">
             <string>5</string>
            </property>
+           <property name="frame">
+            <bool>false</bool>
+           </property>
            <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -373,8 +543,13 @@
              <height>0</height>
             </size>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
            <property name="text">
-            <string>um</string>
+            <string>μm</string>
            </property>
            <property name="scaledContents">
             <bool>true</bool>
@@ -384,19 +559,50 @@
            </property>
           </widget>
          </item>
+         <item>
+          <spacer name="horizontalSpacer_10">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
        </item>
-	   
-	   <item> <!-- Bend Type -->
-        <layout class="QHBoxLayout" name="horizontalLayout_8">
+       <item>
+        <layout class="QHBoxLayout" name="h07_BendType_Line">
          <property name="spacing">
           <number>5</number>
          </property>
          <property name="sizeConstraint">
-          <enum>QLayout::SetMinimumSize</enum>
+          <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
+         </property>
+         <property name="topMargin">
+          <number>5</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
          </property>
          <item>
-          <widget class="QLabel" name="label">
+          <spacer name="horizontalSpacer_7">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_14">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
              <horstretch>2</horstretch>
@@ -415,8 +621,19 @@
              <height>0</height>
             </size>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
            <property name="text">
-            <string>Bend Type, Parameter:</string> 
+            <string>Bend Type:</string>
+           </property>
+           <property name="scaledContents">
+            <bool>true</bool>
+           </property>
+           <property name="wordWrap">
+            <bool>false</bool>
            </property>
           </widget>
          </item>
@@ -440,16 +657,102 @@
              <height>0</height>
             </size>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
+           <property name="autoFillBackground">
+            <bool>false</bool>
+           </property>
            <property name="text">
-            <string>bezier</string>
+            <string>Bezier</string>
+           </property>
+           <property name="frame">
+            <bool>false</bool>
            </property>
            <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
-		 
-		 <item>
+         <item>
+          <widget class="QLabel" name="label_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>2</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_11">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="h08_Parameter_Line" stretch="0,0,0,0,0">
+         <property name="spacing">
+          <number>5</number>
+         </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
+         </property>
+         <property name="topMargin">
+          <number>5</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
+         <item>
+          <spacer name="horizontalSpacer_8">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_3">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>2</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Bend Parameter:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QLineEdit" name="bend_parameter">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
@@ -463,115 +766,45 @@
              <height>20</height>
             </size>
            </property>
-           <property name="sizeIncrement">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
+           <property name="autoFillBackground">
+            <bool>false</bool>
            </property>
            <property name="text">
             <string>0.45</string>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-		 
-		 
-		 <item>
-          <widget class="QCheckBox" name="adiabatic">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-             <horstretch>2</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>70</width>
-             <height>25</height>
-            </size>
-           </property>
-           <property name="sizeIncrement">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Adiabatic</string>
-           </property>
-          </widget>
-         </item>
-		 
-		 
-         <item>
-          <widget class="QLabel" name="label_13">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-             <horstretch>2</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>21</width>
-             <height>21</height>
-            </size>
-           </property>
-           <property name="sizeIncrement">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="text">
-            <string></string>
-           </property>
-           <property name="scaledContents">
-            <bool>true</bool>
-           </property>
-           <property name="wordWrap">
+           <property name="frame">
             <bool>false</bool>
            </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
           </widget>
          </item>
-        </layout>
-       </item>
-	   
-	   
-
-       <item> <!-- Bezier Parameter -->
-        <layout class="QHBoxLayout" name="horizontalLayout_9">
-         <property name="spacing">
-          <number>5</number>
-         </property>
-         <property name="sizeConstraint">
-          <enum>QLayout::SetMinimumSize</enum>
-         </property>
-		 
-        </layout>
-       </item>
-	   
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_10">
-         <property name="spacing">
-          <number>5</number>
-         </property>
-         <property name="sizeConstraint">
-          <enum>QLayout::SetMinimumSize</enum>
-         </property>
          <item>
-          <spacer name="horizontalSpacer_3">
+          <widget class="QLabel" name="label_4">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>2</horstretch>
+             <verstretch>1</verstretch>
             </sizepolicy>
            </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_12">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -581,6 +814,22 @@
            </property>
           </spacer>
          </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="h09_OkCancel_Line">
+         <property name="spacing">
+          <number>5</number>
+         </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
+         </property>
+         <property name="topMargin">
+          <number>5</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
          <item>
           <widget class="QPushButton" name="ok">
            <property name="sizePolicy">
@@ -600,6 +849,11 @@
              <width>0</width>
              <height>0</height>
             </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Ok</string>
@@ -632,6 +886,11 @@
              <height>0</height>
             </size>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
            <property name="text">
             <string>Cancel</string>
            </property>
@@ -639,25 +898,6 @@
             <string>Esc</string>
            </property>
           </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_4">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
          </item>
         </layout>
        </item>

--- a/klayout_dot_config/python/SiEPIC/files/waveguide_gui.ui
+++ b/klayout_dot_config/python/SiEPIC/files/waveguide_gui.ui
@@ -196,7 +196,8 @@
          </property>
         </widget>
        </item>
-       <item>
+	   
+       <item> <!-- Width -->
         <layout class="QHBoxLayout" name="horizontalLayout_8">
          <property name="spacing">
           <number>5</number>
@@ -290,7 +291,8 @@
          </item>
         </layout>
        </item>
-       <item>
+	   
+       <item> <!-- Radius -->
         <layout class="QHBoxLayout" name="horizontalLayout_8">
          <property name="spacing">
           <number>5</number>
@@ -319,10 +321,10 @@
             </size>
            </property>
            <property name="text">
-            <string>Radius:</string>
+            <string>Radius:</string> 
            </property>
           </widget>
-         </item>
+         </item> 
          <item>
           <widget class="QLineEdit" name="radius">
            <property name="sizePolicy">
@@ -384,8 +386,9 @@
          </item>
         </layout>
        </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_9">
+	   
+	   <item> <!-- Bend Type -->
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
          <property name="spacing">
           <number>5</number>
          </property>
@@ -393,7 +396,7 @@
           <enum>QLayout::SetMinimumSize</enum>
          </property>
          <item>
-          <widget class="QLabel" name="label_14">
+          <widget class="QLabel" name="label">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
              <horstretch>2</horstretch>
@@ -413,18 +416,41 @@
             </size>
            </property>
            <property name="text">
-            <string>Bezier Parameter:</string>
-           </property>
-           <property name="scaledContents">
-            <bool>true</bool>
-           </property>
-           <property name="wordWrap">
-            <bool>false</bool>
+            <string>Bend Type, Parameter:</string> 
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QLineEdit" name="bezier">
+          <widget class="QLineEdit" name="bend_type">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>41</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="sizeIncrement">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>bezier</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+		 
+		 <item>
+          <widget class="QLineEdit" name="bend_parameter">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
              <horstretch>1</horstretch>
@@ -451,7 +477,9 @@
            </property>
           </widget>
          </item>
-         <item>
+		 
+		 
+		 <item>
           <widget class="QCheckBox" name="adiabatic">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
@@ -476,8 +504,56 @@
            </property>
           </widget>
          </item>
+		 
+		 
+         <item>
+          <widget class="QLabel" name="label_13">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <horstretch>2</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>21</width>
+             <height>21</height>
+            </size>
+           </property>
+           <property name="sizeIncrement">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string></string>
+           </property>
+           <property name="scaledContents">
+            <bool>true</bool>
+           </property>
+           <property name="wordWrap">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
+	   
+	   
+
+       <item> <!-- Bezier Parameter -->
+        <layout class="QHBoxLayout" name="horizontalLayout_9">
+         <property name="spacing">
+          <number>5</number>
+         </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SetMinimumSize</enum>
+         </property>
+		 
+        </layout>
+       </item>
+	   
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_10">
          <property name="spacing">

--- a/klayout_dot_config/python/SiEPIC/utils/__init__.py
+++ b/klayout_dot_config/python/SiEPIC/utils/__init__.py
@@ -508,7 +508,7 @@ def load_Waveguides_by_Tech(tech_name, debug=False):
             if not 'model' in waveguide.keys():
                 waveguide['model'] = ''
             if not 'bend_type' in waveguide.keys():
-                waveguide['bend_type'] = 'bezier'
+                waveguide['bend_type'] = 'Bezier'
     if not(waveguides):
         print('No waveguides found for technology=%s. Check that there exists a technology definition file %s.lyt and WAVEGUIDES.xml file' % (tech_name, tech_name) )
     

--- a/klayout_dot_config/python/SiEPIC/utils/__init__.py
+++ b/klayout_dot_config/python/SiEPIC/utils/__init__.py
@@ -34,6 +34,7 @@ arc
 arc_wg
 arc_wg_xy
 arc_bezier
+euler_bend
 arc_to_waveguide
 translate_from_normal
 pt_intersects_segment
@@ -367,6 +368,7 @@ def get_technology(verbose=False, query_activecellview_technology=False):
             return get_technology_by_name(technology_name)
         except:
             lv = None
+            technology_name = 'EBeam'
 
     if lv == None:
         # no layout open; return a default technology
@@ -406,8 +408,8 @@ def load_Waveguides():
 
     return waveguides if waveguides else None
 
-#from functools import lru_cache
-#@lru_cache(maxsize=None)
+from functools import lru_cache
+@lru_cache(maxsize=None)
 def load_Waveguides_by_Tech(tech_name, debug=False):
     '''
     Load Waveguide configuration for specific technology
@@ -470,27 +472,51 @@ def load_Waveguides_by_Tech(tech_name, debug=False):
                         waveguides.append(waveguides1['waveguides']['waveguide'])
                 except:
                     pass
+                print("waveguides1: {}".format(waveguides1))
         for waveguide in waveguides:
             if 'component' in waveguide.keys():
                 if not isinstance(waveguide['component'], list):
                     waveguide['component'] = [waveguide['component']]
-            if not 'bezier' in waveguide.keys():
-                waveguide['adiabatic'] = False
-                waveguide['bezier'] = ''
+            
+            if not 'bend_parameter' in waveguide.keys():
+                if not 'bezier' in waveguide.keys():
+                    waveguide['adiabatic'] = False
+                    waveguide['bend_parameter'] = ''
+                    waveguide['bezier'] = ''
+                else:
+                    waveguide['adiabatic'] = True
+                    waveguide['bend_parameter'] = waveguide['bezier']
             else:
                 waveguide['adiabatic'] = True
+                waveguide['bezier'] = waveguide['bend_parameter']
+            
+            
+            
+            # if not 'bend_parameter' in waveguide.keys():
+            #     waveguide['adiabatic'] = False
+            #     waveguide['bend_parameter'] = ''
+            # else:
+            #     waveguide['adiabatic'] = True
+                
+            # if not 'bend_parameter' in waveguide.keys():
+            #     waveguide['adiabatic'] = False
+            #     waveguide['bend_parameter'] = ''
+            # else:
+            #     waveguide['adiabatic'] = True    
+                
+                
             if not 'CML' in waveguide.keys():
                 waveguide['CML'] = ''
             if not 'model' in waveguide.keys():
                 waveguide['model'] = ''
+            if not 'bend_type' in waveguide.keys():
+                waveguide['bend_type'] = 'bezier'
     if not(waveguides):
         print('No waveguides found for technology=%s. Check that there exists a technology definition file %s.lyt and WAVEGUIDES.xml file' % (tech_name, tech_name) )
     
     if debug:
         print('- done: load_Waveguides_by_Tech.  Technology: %s' %(tech_name) )
     return waveguides if waveguides else None
-
-
 
 def load_Calibre():
     '''
@@ -597,7 +623,7 @@ def load_Verification(TECHNOLOGY=None, debug=True):
 
 
 
-def load_DFT(TECHNOLOGY=None, debug=False):
+def load_DFT(TECHNOLOGY=None, debug=True):
     '''
     Load Design-for-Test (DFT) rules
     These are technology specific (SiEPIC definition, TECHNOLOGY), and located in the technology's folder, named DFT.xml. 
@@ -686,8 +712,6 @@ def load_FDTD_settings():
         return FDTD1
     else:
         return None
-
-
 
 
 def load_GC_settings():
@@ -1078,24 +1102,25 @@ def arc_wg_xy(x, y, r, w, theta_start, theta_stop, DevRec=None, dbu=0.001):
 
 from functools import lru_cache
 @lru_cache(maxsize=None)
-def arc_bezier(radius, start, stop, bezier, DevRec=None, dbu=0.001):
+def arc_bezier(radius, start, stop, bend_parameter, DevRec=None, dbu=0.001):    
     '''Create a bezier curve. While there are parameters for start and stop in
     degrees, this is currently only implemented for 90 degree bends
     Radius in Database units (dbu)'''
     from math import sin, cos, pi
     from SiEPIC.utils import points_per_circle
     N = points_per_circle(radius/1000, dbu=dbu)/4
-    bezier=float(bezier) # in case the input was a string
+    bezier=float(bend_parameter) # in case the input was a string
     if DevRec:
         N = int(N / 3)
     else:
         N = int(N)
     if N < 5:
       N = 100
+    print("N = {}".format(N))
     L = radius  # effective bend radius / Length of the bend
     diff = 1. / (N - 1)  # convert int to float
-    xp = [0, (1 - bezier) * L, L, L]
-    yp = [0, 0, bezier * L, L]
+    xp = [0, (1 - bezier)*L, L, L]
+    yp = [0, 0, bezier*L, L]
     xA = xp[3] - 3 * xp[2] + 3 * xp[1] - xp[0]
     xB = 3 * xp[2] - 6 * xp[1] + 3 * xp[0]
     xC = 3 * xp[1] - 3 * xp[0]
@@ -1104,15 +1129,102 @@ def arc_bezier(radius, start, stop, bezier, DevRec=None, dbu=0.001):
     yB = 3 * yp[2] - 6 * yp[1] + 3 * yp[0]
     yC = 3 * yp[1] - 3 * yp[0]
     yD = yp[0]
-
+    
     pts = [pya.Point(-L, 0) + pya.Point(xD, yD)]
     for i in range(1, N - 1):
         t = i * diff
-        pts.append(pya.Point(-L, 0) + pya.Point(t**3 * xA + t**2 * xB +
-                                                t * xC + xD, t**3 * yA + t**2 * yB + t * yC + yD))
+        pts.append(pya.Point(-L, 0) + pya.Point(t**3 * xA + t**2 * xB + t * xC + xD, t**3 * yA + t**2 * yB + t * yC + yD))
     pts.extend([pya.Point(0, L)])
+    print("Bezier pts: {}".format(pts))
     return pts
 
+from functools import lru_cache
+@lru_cache(maxsize=None)
+def euler_bend(radius, p=0.25, DevRec=None, dbu=0.001, debug=False):
+    '''Function to create points for a 90 degree euler bend of 
+    optional radius and with a user-specified bend parameter 'p'.
+    Inspired from GDS factory code [1] and the 2019 Vogelbacher et al. paper:
+    'Analysis of silicon nitride partial Euler waveguide bends' [2].
+    
+    [1] https://github.com/gdsfactory/gdsfactory/blob/main/gdsfactory/path.py
+    [2] https://dx.doi.org/10.1364/oe.27.031394
+    
+        INPUTS:
+            radius (float): desired effective radius 
+            p (float): bend parameter, must be between 0.0 and 1.0
+    '''
+    from SiEPIC.utils import points_per_circle
+    import numpy as np
+    import scipy.integrate as integrate
+    
+    N = points_per_circle(radius/1000, dbu=dbu)/4
+    if DevRec:
+        N = int(N / 3)
+    else:
+        N = int(N)
+    if N < 5:
+      N = 100
+
+    # Internal variables
+    angle = 90
+    npoints = 300
+    npoints = int(N)
+    if debug:
+        print("N = {}".format(npoints))
+    R0 = 1
+    alpha = np.radians(angle)
+    Rp = R0 / np.sqrt(p * alpha)
+    sp = R0 * np.sqrt(p * alpha)
+    s0 = 2 * sp + Rp * alpha * (1 - p)
+    
+    # The minimum radius is Rp
+    Rmin = Rp
+
+    # Allocate points for euler-bend and circular sections
+    num_pts_euler = int(np.round(sp / (s0 / 2) * npoints))
+    num_pts_arc = npoints - num_pts_euler
+
+    # Calculate [x,y] of euler-bend by numerically solving fresnel integrals
+    s_euler = np.linspace(0, sp, num_pts_euler)
+    xbend1 = np.zeros(num_pts_euler)
+    ybend1 = np.zeros(num_pts_euler)
+    for i, s_pt in enumerate(s_euler):
+        xbend1[i], _ = integrate.quad(lambda t: np.cos((t/R0)**2 / 2), 0, s_pt)
+        ybend1[i], _ = integrate.quad(lambda t: np.sin((t/R0)**2 / 2), 0, s_pt)
+
+    # Determine the offset for the circular section
+    xp, yp = xbend1[-1], ybend1[-1]
+    dx = xp - Rp * np.sin(p * alpha / 2)
+    dy = yp - Rp * (1 - np.cos(p * alpha / 2))
+
+    # Calculate [x,y] for the circular-bend section
+    s_arc = np.linspace(sp, s0 / 2, num_pts_arc)
+    xbend2 = Rp * np.sin((s_arc - sp) / Rp + p * alpha / 2) + dx
+    ybend2 = Rp * (1 - np.cos((s_arc - sp) / Rp + p * alpha / 2)) + dy
+
+    # Join euler-bend and circular sections
+    x = np.concatenate([xbend1, xbend2[1:]])
+    y = np.concatenate([ybend1, ybend2[1:]])
+
+    # Evaluate effective radius before re-scaling
+    Reff = x[-1] + y[-1]
+
+    # Determine second half of the bend as the a mirror of the first
+    points2 = np.array([np.flipud(Reff - y), np.flipud(Reff - x)]).T
+
+    # Scale the curve to match the desired radius
+    scale = radius / Reff
+    points = np.concatenate([np.array([x, y]).T[:-1], points2]) * scale
+
+    # Create array of "Point" types
+    pts = []
+    for i in range(len(points)):
+        pts.append(pya.Point(points[i,0] - radius, points[i,1]))  
+    
+    if debug:
+        print("Euler pts: {}".format(pts))
+    
+    return pts
 
 def arc_to_waveguide(pts, width):
     '''Take a list of points and create a polygon of width 'width' '''

--- a/klayout_dot_config/python/SiEPIC/utils/__init__.py
+++ b/klayout_dot_config/python/SiEPIC/utils/__init__.py
@@ -472,7 +472,6 @@ def load_Waveguides_by_Tech(tech_name, debug=False):
                         waveguides.append(waveguides1['waveguides']['waveguide'])
                 except:
                     pass
-                print("waveguides1: {}".format(waveguides1))
         for waveguide in waveguides:
             if 'component' in waveguide.keys():
                 if not isinstance(waveguide['component'], list):
@@ -621,9 +620,7 @@ def load_Verification(TECHNOLOGY=None, debug=True):
         return None
 
 
-
-
-def load_DFT(TECHNOLOGY=None, debug=True):
+def load_DFT(TECHNOLOGY=None, debug=False):
     '''
     Load Design-for-Test (DFT) rules
     These are technology specific (SiEPIC definition, TECHNOLOGY), and located in the technology's folder, named DFT.xml. 
@@ -1116,7 +1113,6 @@ def arc_bezier(radius, start, stop, bend_parameter, DevRec=None, dbu=0.001):
         N = int(N)
     if N < 5:
       N = 100
-    print("N = {}".format(N))
     L = radius  # effective bend radius / Length of the bend
     diff = 1. / (N - 1)  # convert int to float
     xp = [0, (1 - bezier)*L, L, L]
@@ -1135,7 +1131,6 @@ def arc_bezier(radius, start, stop, bend_parameter, DevRec=None, dbu=0.001):
         t = i * diff
         pts.append(pya.Point(-L, 0) + pya.Point(t**3 * xA + t**2 * xB + t * xC + xD, t**3 * yA + t**2 * yB + t * yC + yD))
     pts.extend([pya.Point(0, L)])
-    print("Bezier pts: {}".format(pts))
     return pts
 
 from functools import lru_cache

--- a/klayout_dot_config/python/SiEPIC/utils/__init__.py
+++ b/klayout_dot_config/python/SiEPIC/utils/__init__.py
@@ -368,7 +368,6 @@ def get_technology(verbose=False, query_activecellview_technology=False):
             return get_technology_by_name(technology_name)
         except:
             lv = None
-            technology_name = 'EBeam'
 
     if lv == None:
         # no layout open; return a default technology
@@ -408,8 +407,8 @@ def load_Waveguides():
 
     return waveguides if waveguides else None
 
-from functools import lru_cache
-@lru_cache(maxsize=None)
+# from functools import lru_cache
+# @lru_cache(maxsize=None)
 def load_Waveguides_by_Tech(tech_name, debug=False):
     '''
     Load Waveguide configuration for specific technology
@@ -1115,8 +1114,8 @@ def arc_bezier(radius, start, stop, bend_parameter, DevRec=None, dbu=0.001):
       N = 100
     L = radius  # effective bend radius / Length of the bend
     diff = 1. / (N - 1)  # convert int to float
-    xp = [0, (1 - bezier)*L, L, L]
-    yp = [0, 0, bezier*L, L]
+    xp = [0, (1 - bezier) * L, L, L]
+    yp = [0, 0, bezier * L, L]
     xA = xp[3] - 3 * xp[2] + 3 * xp[1] - xp[0]
     xB = 3 * xp[2] - 6 * xp[1] + 3 * xp[0]
     xC = 3 * xp[1] - 3 * xp[0]

--- a/klayout_dot_config/python/SiEPIC/utils/layout.py
+++ b/klayout_dot_config/python/SiEPIC/utils/layout.py
@@ -344,7 +344,7 @@ def layout_waveguide3(cell, pts, params, debug=False, drawRec=True):
     return waveguide_length
 
 
-def layout_waveguide2(TECHNOLOGY, layout, cell, layers, widths, offsets, pts, radius, adiab, bend_parameter, sbends = True, bend_type = "bezier"):
+def layout_waveguide2(TECHNOLOGY, layout, cell, layers, widths, offsets, pts, radius, adiab, bend_parameter, sbends = True, bend_type = "Bezier"):
     '''
     Create a waveguide, in a specific technology
     inputs
@@ -483,10 +483,10 @@ def layout_waveguide2(TECHNOLOGY, layout, cell, layers, widths, offsets, pts, ra
             if abs(turn) == 1:
                 if(adiab):
                     # Select type of adiabatic bend based on WAVEGUIDES.XML file
-                    if bend_type == "euler":
+                    if bend_type == "Euler":
                         wg_pts += Path(euler_bend(pt_radius, float(bend_parameter),
                             DevRec='DevRec' in layers[lr], dbu=dbu), 0).transformed(Trans(angle, turn < 0, pts[i])).get_points()
-                    elif bend_type == "bezier":
+                    elif bend_type == "Bezier":
                         wg_pts += Path(arc_bezier(pt_radius, 270, 270 + inner_angle_b_vectors(pts[i-1]-pts[i], pts[i+1]-pts[i]), float(bend_parameter), 
                             DevRec='DevRec' in layers[lr], dbu=dbu), 0).transformed(Trans(angle, turn < 0, pts[i])).get_points()
                     else:

--- a/klayout_dot_config/python/SiEPIC/utils/layout.py
+++ b/klayout_dot_config/python/SiEPIC/utils/layout.py
@@ -34,171 +34,6 @@ from functools import reduce
 from .sampling import sample_function
 from .geometry import rotate90, rotate, bezier_optimal, curve_length
 
-def layout_waveguide5(cell, dpath, waveguide_type, debug=True):
-
-    if debug:
-        print('SiEPIC.utils.layout.layout_waveguide5: ')
-        print(' - waveguide_type: %s' % (waveguide_type))
-
-    # get the path and clean it up
-    layout = cell.layout()
-    dbu = layout.dbu
-    dpath = dpath.to_itype(dbu)
-    dpath.unique_points()
-    pts = dpath.get_points()
-    dpts = dpath.get_dpoints()
-
-    # Load the technology and all waveguide types
-    from SiEPIC.utils import load_Waveguides_by_Tech
-    technology_name = layout.technology_name
-    waveguide_types = load_Waveguides_by_Tech(technology_name)
-    if debug:
-        print(' - technology_name: %s' % (technology_name))
-        print(' - waveguide_types: %s' % (waveguide_types))
-
-    # Load parameters for the chosen waveguide type
-    params = [t for t in waveguide_types if t['name'] == waveguide_type]
-
-    print('params: {}'.format(params))
-
-    if type(params) == type([]) and len(params) > 0:
-        params = params[0]
-        if 'width' not in params and 'compound_waveguide' not in params:
-            params['width'] = params['wg_width']
-        params['waveguide_type'] = waveguide_type
-    else:
-        print('error: waveguide type not found in PDK waveguides')
-        raise Exception('error: waveguide type (%s) not found in PDK waveguides' %
-                        waveguide_type)
-
-    # compound waveguide types:
-    if 'compound_waveguide' in params:
-        # find the singlemode and multimode waveguides:
-        if 'singlemode' in params['compound_waveguide']:
-            singlemode = params['compound_waveguide']['singlemode']
-        else:
-            raise Exception(
-                'error: waveguide type (%s) does not have singlemode defined' % waveguide_type)
-        if 'multimode' in params['compound_waveguide']:
-            multimode = params['compound_waveguide']['multimode']
-        else:
-            raise Exception(
-                'error: waveguide type (%s) does not have multimode defined' % waveguide_type)
-        params_singlemode = [t for t in waveguide_types if t['name'] == singlemode]
-        params_multimode = [t for t in waveguide_types if t['name'] == multimode]
-        if type(params_singlemode) == type([]) and len(params_singlemode) > 0:
-            params_singlemode = params_singlemode[0]
-            params_singlemode['waveguide_type'] = singlemode
-        else:
-            raise Exception(
-                'error: waveguide type (%s) not found in PDK waveguides' % singlemode)
-        if type(params_multimode) == type([]) and len(params_multimode) > 0:
-            params_multimode = params_multimode[0]
-            params_multimode['waveguide_type'] = multimode
-        else:
-            raise Exception(
-                'error: waveguide type (%s) not found in PDK waveguides' % multimode)
-        # find the taper
-        if 'taper_library' in params['compound_waveguide'] and 'taper_cell' in params['compound_waveguide']:
-            taper = layout.create_cell(
-                params['compound_waveguide']['taper_cell'], params['compound_waveguide']['taper_library'])
-            if not taper:
-                raise Exception('Cannot import cell %s : %s' % (
-                    params['compound_waveguide']['taper_cell'], params['compound_waveguide']['taper_library']))
-        else:
-            raise Exception(
-                'error: waveguide type (%s) does not have taper cell and library defined' % waveguide_type)
-        from pya import Trans, CellInstArray
-
-        '''
-        find sections of waveguides that are larger than (2 x radius + 2 x taper_length)
-         - insert two tapers
-         - insert multimode straight section
-         - insert singlemode waveguides (including bends) before
-        '''
-        import math
-        from SiEPIC.extend import to_itype
-        from pya import Point
-        radius = to_itype(params_singlemode['radius'], dbu)
-        pins, _ = taper.find_pins()
-        taper_length = pins[0].center.distance(pins[1].center)
-        min_length = 2*radius + 2*taper_length
-        offset = radius
-        wg_sm_segment_pts = []
-        wg_last = 0
-        waveguide_length = 0
-        for ii in range(1, len(dpts)):
-            start_point = dpts[ii-1]
-            end_point = dpts[ii]
-            distance_points = end_point.distance(start_point)
-            if distance_points < min_length:
-                # single mode segment, keep track
-                if ii == 1:
-                    wg_sm_segment_pts.append(pts[ii-1])
-                wg_sm_segment_pts.append(pts[ii])
-                if ii == len(pts)-1:
-                    subcell = layout.create_cell("Waveguide_sm_%s" % ii)
-                    cell.insert(CellInstArray(subcell.cell_index(), Trans()))
-                    waveguide_length += layout_waveguide3(subcell,
-                                                          wg_sm_segment_pts, params_singlemode, debug=False)
-            else:
-                # insert two tapers and multimode waveguide
-                angle = math.atan2((end_point.y-start_point.y),
-                                   (end_point.x-start_point.x))/math.pi*180
-                if ii == 1:
-                    wg_first = offset
-                else:
-                    wg_first = 0
-                if ii == len(pts)-1:
-                    wg_last = offset
-                if round(angle) % 360 == 270.0:
-                    t = Trans(Trans.R270, start_point.x, start_point.y-offset+wg_first)
-                    t2 = Trans(Trans.R90, end_point.x, end_point.y+offset-wg_last)
-                    wg_start_pt = Point(start_point.x, start_point.y -
-                                        offset-taper_length+wg_first)
-                    wg_end_pt = Point(end_point.x, end_point.y+offset+taper_length-wg_last)
-                if round(angle) % 360 == 90.0:
-                    t = Trans(Trans.R90, start_point.x, start_point.y+offset-wg_first)
-                    t2 = Trans(Trans.R270, end_point.x, end_point.y-offset+wg_last)
-                    wg_start_pt = Point(start_point.x, start_point.y +
-                                        offset+taper_length-wg_first)
-                    wg_end_pt = Point(end_point.x, end_point.y-offset-taper_length+wg_last)
-                if round(angle) % 360 == 180.0:
-                    t = Trans(Trans.R180, start_point.x-offset+wg_first, start_point.y)
-                    t2 = Trans(Trans.R0, end_point.x+offset-wg_last, end_point.y)
-                    wg_start_pt = Point(start_point.x-offset -
-                                        taper_length+wg_first, start_point.y)
-                    wg_end_pt = Point(end_point.x+offset+taper_length-wg_last, end_point.y)
-                if round(angle) % 360 == 0.0:
-                    t = Trans(Trans.R0, start_point.x+offset-wg_first, start_point.y)
-                    t2 = Trans(Trans.R180, end_point.x-offset+wg_last, end_point.y)
-                    wg_start_pt = Point(start_point.x+offset +
-                                        taper_length-wg_first, start_point.y)
-                    wg_end_pt = Point(end_point.x-offset-taper_length+wg_last, end_point.y)
-                inst_taper = cell.insert(CellInstArray(taper.cell_index(), t))
-                inst_taper = cell.insert(CellInstArray(taper.cell_index(), t2))
-                waveguide_length += taper_length*2
-                subcell = layout.create_cell("Waveguide_mm_%s" % ii)
-                cell.insert(CellInstArray(subcell.cell_index(), Trans()))
-                waveguide_length += layout_waveguide3(subcell,
-                                                      [wg_start_pt, wg_end_pt], params_multimode, debug=False)
-                # compound segment
-                if ii > 1:
-                    wg_sm_segment_pts.append(t.disp.to_p())
-                    subcell = layout.create_cell("Waveguide_sm_%s" % ii)
-                    cell.insert(CellInstArray(subcell.cell_index(), Trans()))
-                    waveguide_length += layout_waveguide3(subcell,
-                                                          wg_sm_segment_pts, params_singlemode, debug=False)
-                    wg_sm_segment_pts = [t2.disp.to_p(), pts[ii]]
-                else:
-                    wg_sm_segment_pts = [t2.disp.to_p(), pts[ii]]
-
-    else:
-        # primitive waveguide type
-        waveguide_length = layout_waveguide3(cell, pts, params, debug=False)
-
-    return waveguide_length
-
 
 def layout_waveguide4(cell, dpath, waveguide_type, debug=False):
     '''
@@ -371,12 +206,9 @@ acknowledgements: Diedrik Vermeulen for the code to place the taper in the corre
 
     else:
         # primitive waveguide type
-        print("Params: {}".format(params))
         waveguide_length = layout_waveguide3(cell, pts, params, debug=False)
 
     return waveguide_length
-
-
 
 
 
@@ -1422,7 +1254,7 @@ def y_splitter_tree(cell, tree_depth=4, y_splitter_cell="y_splitter_1310", libra
 
 
 
-def floorplan(topcell, x, y, centered=False):
+def floorplan(topcell, x, y, centered=False, layer_name='FloorPlan'):
     '''Create a FloorPlan, from (0,0) to (x,y), or centered
     by Lukas Chrostowski, 2023, SiEPIC-Tools
     '''
@@ -1433,7 +1265,7 @@ def floorplan(topcell, x, y, centered=False):
         box = pya.Box(0,0,x,y)
     else:
         box = pya.Box(-x/2,-y/2,x/2,y/y)
-    cell.shapes(ly.layer(ly.TECHNOLOGY['FloorPlan'])).insert(box)
+    cell.shapes(ly.layer(ly.TECHNOLOGY[layer_name])).insert(box)
     return inst
 
 def new_layout(tech, topcell_name, GUI=True, overwrite = False):


### PR DESCRIPTION
**waveguide_gui.ui**
-	Added ‘bend_type’ field which can either be specified as ‘bezier’ or ‘euler’
o	‘bezier’ is the default/backwards compatible parameter for old ‘WAVEGUIDES.xml’ files
o	‘euler’ is a new option that will create euler bends
-	Changed ‘bezier’ parameter to ‘bend_parameter’ which can be either the bezier parameter or the p-parameter for euler bends

![image](https://github.com/user-attachments/assets/213c116c-313a-41ac-bd52-22580ca4031b)
 
**siepic_tools > core.py > WaveguideGUI( ) class**
config_changed( )
-	Added capability to read ‘bend_type’ from waveguide GUI
o	If ‘bend_type’ is not specified, the type is set to ‘bezier’
o	If ‘adiabatic’ is false, set ‘bend_parameter’ to an empty string

get_parameters( )
-	Added ‘bend_type’ to ‘params’ dictionary
-	Changed ‘bezier’ to ‘bend_parameter’ in ‘params’ dictionary

**utils > init.py**
load_waveguides_by_tech( )
-	If ‘bend_parameter’ is not a given field, but ‘bezier’ is, set ‘bend_parameter’ = ‘bezier’ (for reverse compatability)
-	if bend_parameter is specified, also set ‘bezier’ to ‘bend_parameter’ to avoid unforeseen compatibility issues with anything else that looks for ‘bezier’

euler_bend( )
-	Created euler bend function that takes p parameter and r as inputs and creates an euler bend with effective radius r. Returns a set of points that trace out the curve like the ‘arc_bezier’ function

**layout.py**
layout_waveguide3( )
-	If no ‘bend_parameter’ is specified, adiabatic is set to false and bend_parameter is set to an empty sting 
-	Added bend_parameter and bend_type to inputs of layout_waveguide2() function call

layout_waveguide2()
-	Added ‘bend_parameter’ and ‘bend_type’ to inputs
-	If adiabatic and euler is specified, create euler bend
-	If adiabatic and bezier is specified, create Bezier bend
 
![image](https://github.com/user-attachments/assets/e0bb762a-e4b4-4a93-893c-daba0a78dafe)

